### PR TITLE
Fixing a couple compiler warnigs

### DIFF
--- a/fmt_opts.cpp
+++ b/fmt_opts.cpp
@@ -15,6 +15,10 @@ std::string formatting_options::get_par_str() const
       break;
    case formatting_options::align_justify:
       style+="text-align:justify;";
+      break;
+   case formatting_options::align_left:
+   case formatting_options::align_error:
+      break;
    }
    if (papFirst!=0)
    {
@@ -216,6 +220,7 @@ std::string formatter::format(const formatting_options &_opt)
       case font::ff_cursive: style+=", cursive"; break;
       case font::ff_fantasy: style+=", fantasy"; break;
       case font::ff_monospace: style+=", monospace"; break;
+      case font::ff_none: break;
       }
       style+=";";
    }

--- a/rtf2html.cpp
+++ b/rtf2html.cpp
@@ -191,10 +191,10 @@ int main(int argc, char **argv)
                      {
                      case '\\':
                      {
-                        rtf_keyword kw(++buf_in);
-                        if (in_title && kw.is_control_char() && kw.control_char() == '\'')
+                        rtf_keyword kw1(++buf_in);
+                        if (in_title && kw1.is_control_char() && kw1.control_char() == '\'')
                            title += char_by_code(buf_in);
-                        else if (kw.keyword()==rtf_keyword::rkw_title)
+                        else if (kw1.keyword()==rtf_keyword::rkw_title)
                            in_title=true;
                         break;
                      }
@@ -224,17 +224,19 @@ int main(int argc, char **argv)
                      {
                      case '\\':
                      {
-                        rtf_keyword kw(++buf_in);
-                        switch (kw.keyword())
+                        rtf_keyword kw1(++buf_in);
+                        switch (kw1.keyword())
                         {
                         case rtf_keyword::rkw_red:
-                           clr.r=kw.parameter();
+                           clr.r=kw1.parameter();
                            break;
                         case rtf_keyword::rkw_green:
-                           clr.g=kw.parameter();
+                           clr.g=kw1.parameter();
                            break;
                         case rtf_keyword::rkw_blue:
-                           clr.b=kw.parameter();
+                           clr.b=kw1.parameter();
+                           break;
+                        default:
                            break;
                         }
                         break;
@@ -264,20 +266,20 @@ int main(int argc, char **argv)
                      {
                      case '\\':
                      {
-                        rtf_keyword kw(++buf_in);
-                        if (kw.is_control_char() && kw.control_char()=='*')
+                        rtf_keyword kw1(++buf_in);
+                        if (kw1.is_control_char() && kw1.control_char()=='*')
                            skip_group(buf_in);
                         else
-                           switch (kw.keyword())
+                           switch (kw1.keyword())
                            {
                            case rtf_keyword::rkw_f:
-                              font_num=kw.parameter();
+                              font_num=kw1.parameter();
                               break;
                            case rtf_keyword::rkw_fprq:
-                              fnt.pitch=kw.parameter();
+                              fnt.pitch=kw1.parameter();
                               break;
                            case rtf_keyword::rkw_fcharset:
-                              fnt.charset=kw.parameter();
+                              fnt.charset=kw1.parameter();
                               break;
                            case rtf_keyword::rkw_fnil:
                               fnt.family=font::ff_none;
@@ -296,6 +298,8 @@ int main(int argc, char **argv)
                               break;
                            case rtf_keyword::rkw_fdecor:
                               fnt.family=font::ff_fantasy;
+                              break;
+                           default:
                               break;
                            }
                         break;
@@ -479,6 +483,7 @@ int main(int argc, char **argv)
                case rtf_keyword::rkw_trowd: 
                   CurCellDefs=CellDefsList.insert(CellDefsList.end(), 
                                                   table_cell_defs());
+                  // fall through
                case rtf_keyword::rkw_row:
                   if (!trCurRow->Cells.empty())
                   {
@@ -556,6 +561,8 @@ int main(int argc, char **argv)
                   break;
                case rtf_keyword::rkw_margl:
                   iMarginLeft=kw.parameter();
+                  break;
+               default:
                   break;
                }
             }

--- a/rtf_table.cpp
+++ b/rtf_table.cpp
@@ -199,6 +199,8 @@ std::string table::make()
             case table_cell_def::valign_bottom:
                result+=" valign=bottom";
                break;
+            case table_cell_def::valign_center:
+               break;
             }
 
             result+=">";

--- a/rtf_table.cpp
+++ b/rtf_table.cpp
@@ -88,9 +88,7 @@ std::string table::make()
                cell_def_2=
                    std::find_if((*span_row)->CellDefs->begin(),
                                 (*span_row)->CellDefs->end(),
-                                std::bind2nd(
-                                   std::mem_fun(&table_cell_def::right_equals),
-                                                (*cell_def)->Right));
+                                [cell_def](table_cell_def* def) { return def->right_equals((*cell_def)->Right); });
                if (cell_def_2==(*span_row)->CellDefs->end())
                   break;
                if (!(*cell_def_2)->Merged)
@@ -139,9 +137,7 @@ std::string table::make()
                cell_def_2=
                    std::find_if((*row2)->CellDefs->begin(),
                                 (*row2)->CellDefs->end(),
-                                std::bind2nd(
-                                   std::mem_fun(&table_cell_def::right_equals), 
-                                                left));
+                                [left](table_cell_def* def) { return def->right_equals(left); } );
                if (cell_def_2!=(*row2)->CellDefs->end())
                {
                   bleft=bleft && (*cell_def_2)->BorderRight;
@@ -149,9 +145,7 @@ std::string table::make()
                cell_def_2=
                    std::find_if((*row2)->CellDefs->begin(),
                                 (*row2)->CellDefs->end(),
-                                std::bind2nd(
-                                   std::mem_fun(&table_cell_def::left_equals), 
-                                                right));
+                                [right](table_cell_def* def) { return def->left_equals(right); } );
                if (cell_def_2!=(*row2)->CellDefs->end())
                {
                   bright=bright && (*cell_def_2)->BorderLeft;


### PR DESCRIPTION
Bring the code into sync with what we use in MuseScore (where we use it as a library function, not as a standlone program, this is the remaining difference, plus the change from #9)

See also https://github.com/musescore/MuseScore/pull/5392